### PR TITLE
Double navbar & enter symptom removed 

### DIFF
--- a/Templates/Index.html
+++ b/Templates/Index.html
@@ -95,64 +95,6 @@
   </head>
   <body>
 
-    <!-- Navbar -->
-    <nav class="navbar navbar-expand-lg navbar-dark bg-primary shadow">
-        <div class="container-fluid">
-            <a class="navbar-brand" href="/">Health Care Center</a>
-            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
-                <span class="navbar-toggler-icon"></span>
-            </button>
-            <div class="collapse navbar-collapse" id="navbarNav">
-                <ul class="navbar-nav ms-auto">
-                    <li class="nav-item"><a class="nav-link active" href="/">Home</a></li>
-                    <li class="nav-item"><a class="nav-link" href="/about">About</a></li>
-                    <li class="nav-item"><a class="nav-link" href="/contact">Contact</a></li>
-                    <li class="nav-item"><a class="nav-link" href="/developer">Developer</a></li>
-                    <li class="nav-item"><a class="nav-link" href="/blog">Blog</a></li>
-                </ul>
-                <form class="d-flex ms-3 position-relative" role="search">
-                    <input class="form-control me-2" id="searchInput" type="search" placeholder="Search symptoms..." aria-label="Search" autocomplete="off">
-                    <div id="searchResults" class="dropdown-menu" style="display:none; position:absolute; z-index:1000; width:100%;"></div>
-                </form>
-            </div>
-        </div>
-    </nav>
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-    const searchInput = document.getElementById('searchInput');
-    const searchResults = document.getElementById('searchResults');
-
-    searchInput.addEventListener('input', function() {
-        const query = searchInput.value.trim();
-        if (query.length < 2) {
-            searchResults.style.display = 'none';
-            searchResults.innerHTML = '';
-            return;
-        }
-        fetch(`/search?q=${encodeURIComponent(query)}`)
-            .then(response => response.json())
-            .then(data => {
-                if (data.results && data.results.length > 0) {
-                    searchResults.innerHTML = data.results.map(item => `<a class='dropdown-item' href='#'>${item}</a>`).join('');
-                    searchResults.style.display = 'block';
-                } else {
-                    searchResults.innerHTML = '<span class="dropdown-item">No results found</span>';
-                    searchResults.style.display = 'block';
-                }
-            })
-            .catch(() => {
-                searchResults.innerHTML = '<span class="dropdown-item">Error fetching results</span>';
-                searchResults.style.display = 'block';
-            });
-    });
-
-    document.addEventListener('click', function(e) {
-        if (!searchInput.contains(e.target) && !searchResults.contains(e.target)) {
-            searchResults.style.display = 'none';
-        }
-    });
-});
-</script>
   <!-- Navbar -->
     <nav class="navbar navbar-expand-lg navbar-dark" style="background-color: #0542a7;">
   <div class="container-fluid">
@@ -218,8 +160,6 @@ document.addEventListener('DOMContentLoaded', function() {
 
           <button class="btn btn-danger predict-btn">Predict</button>
 
-           <!-- NEW BUTTON ADDED -->
-        <a href="/extra" class="btn extra-btn">Extra Feature</a>
       </form>
     </div>
 
@@ -429,12 +369,6 @@ document.addEventListener("DOMContentLoaded", function () {
   }
 });
 </script>
-<form action="/predict" method="post" class="my-3">
-  <label for="symptoms" class="form-label">Enter symptoms (comma-separated):</label>
-  <input type="text" id="symptoms" name="symptoms" class="form-control" placeholder="itching, skin_rash" required>
-  <button type="submit" class="btn btn-primary mt-2">Predict</button>
-</form>
-
 
 </body>
 </html>

--- a/Templates/Index.html
+++ b/Templates/Index.html
@@ -159,7 +159,9 @@
           </button>
 
           <button class="btn btn-danger predict-btn">Predict</button>
-
+          
+          <!-- NEW BUTTON ADDED -->
+          <a href="/extra" class="btn extra-btn">Extra Feature</a>
       </form>
     </div>
 


### PR DESCRIPTION
Hello , Tushar Sonawane, GSSOC'25 Contributor, here,

For issue #43 ,
Mam, As the dashboard was showing the double navbar , I have removed the upper navbar , as now only 1 navbar (lower) is visible on dashboard. And at the bottom there was option of "Enter symptom comma-seperated" has been removed too.

image before changes:- 
<img width="1366" height="684" alt="medical 1" src="https://github.com/user-attachments/assets/5a851c1e-708a-4888-865e-bdf2882edec6" />
<img width="1355" height="682" alt="Medical 2" src="https://github.com/user-attachments/assets/eed27a98-0532-4767-b4b8-5f87f3d4c21d" />

image after changes:-
<img width="1366" height="686" alt="Medical 3" src="https://github.com/user-attachments/assets/ea10bf42-be43-462b-82cc-794d2dbe51ba" />
